### PR TITLE
fix: package.json の name を ogp に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "weeklycontents",
+  "name": "ogp",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 概要
package.json の name フィールドを "weeklycontents" から "ogp" に変更しました。

## 変更内容
- `package.json` の `name` フィールドを更新

## テスト
- `bun run check` を実行し、リンター・タイプチェックに問題なしを確認

Closes #4

Generated with [Claude Code](https://claude.ai/code)