### PR TITLE
feat: Codespaces での bun run start 確認をサポート

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,8 @@
       "extensions": ["oven.bun-vscode"]
     }
   },
-  "forwardPorts": [5173],
-  "appPort": ["5173:5173"],
+  "forwardPorts": [5173, 8787],
+  "appPort": ["5173:5173", "8787:8787"],
   "runArgs": ["--name", "nw-union-ogp"],
   "postCreateCommand": "bun install --frozen-lockfile"
 }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,11 @@
   },
   "workers_dev": true,
   "preview_urls": true,
+  "dev": {
+    "ip": "0.0.0.0",
+    "port": 8787,
+    "local_protocol": "http"
+  },
   "vars": {},
   "kv_namespaces": [
     {


### PR DESCRIPTION
## 概要

Codespaces で `bun run start` の確認ができるように設定を追加しました。

## 変更内容

- `.devcontainer/devcontainer.json` にポート `8787` を追加
- `wrangler.jsonc` に dev 設定を追加、外部アクセスを許可

Closes #10

Generated with [Claude Code](https://claude.ai/code)