### PR TITLE
fix: PR ワークフローの参照名を修正

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,6 @@ jobs:
 
   # PR の設定確認
   chores:
-    uses: nw-union/.github/.github/workflows/chores.yml@main
+    uses: nw-union/.github/.github/workflows/pr_chores.yml@main
     secrets: inherit
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
   "files": {
     "includes": [
       "**/*.js",
@@ -13,7 +13,8 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "nursery": {
+      "nursery": {},
+      "correctness": {
         "noNestedComponentDefinitions": "off" // コンポーネント内でローカルコンポーネントを定義する場合があるため
       }
     },


### PR DESCRIPTION
## 概要
PRチェック用のワークフロー参照を正しいファイル名に修正しました。

## 関連 Issue
なし

## 変更内容
- `.github/workflows/pull_request.yml` のワークフロー参照を `chores.yml` から `pr_chores.yml` に変更
- `biome.jsonc` の設定を最新版(2.2.2)に移行

## 確認事項
- [x] 必要に応じてテストを追加・更新した
- [x] 必要に応じて関連ドキュメントを更新した

## その他
ワークフローの参照名が間違っていたため、正しいファイル名 `pr_chores.yml` に修正しました。
また、biome設定も併せて最新版に更新しています。

🤖 Generated with [Claude Code](https://claude.ai/code)